### PR TITLE
Init organization docs

### DIFF
--- a/src/drafts/organization/class-diagram.adoc
+++ b/src/drafts/organization/class-diagram.adoc
@@ -1,0 +1,44 @@
+Class diagram
+
+ifdef::env-github[]
+[source,mermaid]
+endif::[]
+ifndef::env-github[]
+[mermaid]
+endif::[]
+....
+classDiagram
+    Folder "0..1" <-- "*" Folder
+    Folder "1" *-- "*" Tag
+    Tag "1" *-- "*" TagCredential
+    Folder "1" *-- "*" CredentialFolder
+    class Folder{
+        +Uuid id
+        +String[] members
+        +String name
+        +String description
+        +String icon
+        +Date created_at
+        +Data updated_at
+        +Uuid parent_id
+        +Uuid created_by
+    }
+    class Tag{
+        +Uuid id
+        +String name
+        +Stringcolor
+        +String icon
+        +Date created_at
+        +Date updated_at
+        +Uuid folder_id
+        +Uuid created_by
+    }
+    class TagCredential{
+        +Uuid id_tag
+        +Uuid id_credential
+    }
+    class CredentialFolder{
+        +Uuid id_credential
+        +Uuid id_folder
+    }
+....

--- a/src/drafts/organization/folder-flow-diagramm.adoc
+++ b/src/drafts/organization/folder-flow-diagramm.adoc
@@ -1,0 +1,58 @@
+== Create a Folder
+
+ifdef::env-github[]
+[source,mermaid]
+endif::[]
+ifndef::env-github[]
+[mermaid]
+endif::[]
+....
+sequenceDiagram
+    participant Frontend
+    participant Organization
+    participant Kafka
+    Frontend->>Organization: CreateFolder
+      Organization->>Organization: Create a Folder
+      Note over Organization: To be developed
+    alt Creation success
+        Organization-->>Kafka: CreateFolderEvent
+        Organization->>Frontend: Folder created
+    else Creation failed
+        Organization->>Frontend: Folder creation failed
+    end
+....
+
+== Add member to Folder
+
+ifdef::env-github[]
+[source,mermaid]
+endif::[]
+ifndef::env-github[]
+[mermaid]
+endif::[]
+....
+sequenceDiagram
+    participant Frontend
+    participant Kafka
+    participant Organization
+    participant MongoDB
+    Frontend->>Organization: ShareFolder
+    Organization->>MongoDB: Verify if member already present in subFolder
+
+    alt Already member of a subFolder
+        MongoDB-->>Organization: Warning
+        Organization->>Organization: Delete rights from subFolder
+    else Not a member of a subFolder
+        MongoDB-->>Organization: Ok
+    end
+
+    Organization->>Organization: Add Member to folder
+
+    alt Share success
+        Organization-->>Kafka: ShareFolderEvent
+        Organization->>Frontend: ShareFolder
+    else Share failed
+        Organization-->>Kafka: ShareFolderEventFailed
+        Organization->>Frontend: ShareFolder Failed
+    end
+....

--- a/src/drafts/organization/interfaces.adoc
+++ b/src/drafts/organization/interfaces.adoc
@@ -1,0 +1,46 @@
+==== Folder
+[source,json]
+----
+{
+  "type":"object",
+  "properties":{
+    "id": {"type":"string", "format": "uuid"},
+    "name": {"type":"string"},
+    "description": {"type":"string"},
+    "icon": {"type":"string"},
+    "created_at": {"type":"string", "format": "date"},
+    "updated_at": {"type":"string", "format": "date"},
+    "parent_id": {"type":"string", "format": "uuid"},
+    "created_by": {"type":"string", "format": "uuid"}
+  }
+}
+----
+
+==== Tag
+[source,json]
+----
+{
+  "type":"object",
+  "properties":{
+    "id": {"type":"string", "format": "uuid" },
+    "name": {"type":"string"},
+    "color": {"type":"string", "format": "hexadecimal"},
+    "created_at": {"type":"string", "format": "date"},
+    "updated_at": {"type":"string", "format": "date"},
+    "folder_id": {"type":"string", "format": "uuid"},
+    "created_by": {"type":"string", "format": "uuid"}
+  }
+}
+----
+
+=== Tag - Credentail
+[source,json]
+----
+{
+  "type":"object",
+  "properties": {
+    "id_tag": {"type":"string", "format": "uuid"},
+    "id_credential": {"type":"string", "format": "uuid"}
+  }
+}
+----

--- a/src/drafts/organization/tag-flow-diagram.adoc
+++ b/src/drafts/organization/tag-flow-diagram.adoc
@@ -1,0 +1,49 @@
+== Attribute a Tag
+
+ifdef::env-github[]
+[source,mermaid]
+endif::[]
+ifndef::env-github[]
+[mermaid]
+endif::[]
+....
+sequenceDiagram
+    participant Frontend
+    participant Organization
+    participant PostgreSQL
+    participant KafkaK
+    Frontend->>Organization: Attribute Tag to credential
+    Organization->>PostgreSQL: Get Tag in Credential folder or parent
+    alt Tag exists
+        PostgreSQL-->>Organization: Tag
+    else Tag doesn't exist
+        PostgreSQL-->>Organization: null
+        Organization->>Organization: Create Tag
+    end
+        Organization->>PostgreSQL: Attribute Tag to Credential
+        Organization->>KafkaK: Publish Tag
+        Organization-->>Frontend: Tag created
+....
+
+"Get Tag in Credential folder or parent" means we will search for the tag in the credential folder and in the parent folders (never in the children).
+
+== Create a Tag
+
+ifdef::env-github[]
+[source,mermaid]
+endif::[]
+ifndef::env-github[]
+[mermaid]
+endif::[]
+....
+sequenceDiagram
+    participant Frontend
+    participant Organization
+    participant PostgreSQL
+    participant KafkaK
+    Frontend->>Organization: Create Tag
+    Organization->>PostgreSQL: Create Tag
+    Organization->>KafkaK: Publish Tag
+    Organization-->>Frontend: Tag created
+....
+


### PR DESCRIPTION
This pull request introduces several new diagrams and interfaces to the documentation of the organization module. The changes include the addition of class diagrams, sequence diagrams for folder and tag operations, and JSON interfaces for folder and tag objects.

### Diagrams and Interfaces:

* **Class Diagrams:**
  - Added a class diagram for `Folder`, `Tag`, `TagCredential`, and `CredentialFolder` classes. (`src/drafts/organization/class-diagram.adoc`)

* **Folder Flow Diagrams:**
  - Added sequence diagrams for creating a folder and adding a member to a folder, detailing interactions between `Frontend`, `Organization`, `Kafka`, and `MongoDB`. (`src/drafts/organization/folder-flow-diagramm.adoc`)

* **Tag Flow Diagrams:**
  - Added sequence diagrams for attributing a tag to a credential and creating a tag, showing interactions between `Frontend`, `Organization`, `PostgreSQL`, and `KafkaK`. (`src/drafts/organization/tag-flow-diagram.adoc`)

* **JSON Interfaces:**
  - Defined JSON interfaces for `Folder`, `Tag`, and `TagCredential` objects, specifying their properties and types. (`src/drafts/organization/interfaces.adoc`)